### PR TITLE
feature/create card container

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,29 @@ En el archivo `package.json` se encuentran definidos los siguientes scripts:
 
 ## Documentación de Componentes
 
-### IconButton
+### Button
 
-- **Descripción**: Componente reutilizable que renderiza un botón con un ícono. Ideal para acciones rápidas en la interfaz de usuario.
+- **Descripción**: Componente reutilizable que puede mostrar un ícono y/o texto, con estilos y variantes personalizables.
+
 - **Props**:
-  - `children`: Componente que representa un ícono.
+  - `icon`: Ícono opcional que se muestra dentro del botón.
+  - `text`: Texto opcional que se muestra dentro del botón.
+  - `customStyle`: Estilo personalizado para el botón.
+  - `variant`: Variante del botón (por ejemplo, `primary`, `secondary`).
   - `onClick`: Función que se ejecuta al hacer clic en el botón.
-  - `customStyle`: Estilo personalizado para el botón (opcional).
 - **Ejemplo de Uso**:
 
   ```tsx
-  import { IconButton } from "./components/IconButton";
+  import { Button } from "./components/Button";
   import { LucideIcon } from "lucide-react";
 
   const Example = () => (
-    <IconButton onClick={() => alert("Clicked!")}>
-      <LucideIcon name="check" />
-    </IconButton>
+    <Button
+      variant="secondary"
+      onClick={() => alert("Clicked!")}
+      text="Click Me"
+      icon={<LucideIcon />}
+    />
   );
   ```
 
@@ -117,23 +123,65 @@ En el archivo `package.json` se encuentran definidos los siguientes scripts:
   ```tsx
   import { LucideIcon } from "lucide-react";
   import styled, { css } from "styled-components";
-  import { IconButton } from "./components/IconButton";
+  import { Button } from "./components/Button";
 
   const ExampleWithStyle = () => (
-    <IconButton
+    <Button
+      text="Styled Button"
+      icon={<LucideIcon name="star" />}
+      onClick={() => alert("Styled Click!")}
+      customStyle={css`{ backgroundColor: "blue", color: "white", padding: "10px" }`}
+    />
+  );
+  ```
+
+### CardContainer
+
+- **Descripción**: Componente contenedor reutilizable que permite mostrar contenido dentro de un diseño estilizado. Ideal para mostrar tarjetas informativas o secciones destacadas en la interfaz de usuario.
+
+- **Props**:
+
+  - `children`: Contenido que se renderiza dentro del contenedor.
+  - `customStyle`: Estilo personalizado para el contenedor, utilizando `styled-components`.
+
+- **Ejemplo de Uso**:
+
+  ```tsx
+  import { CardContainer } from "./components/CardContainer/CardContainer";
+
+  const Example = () => (
+    <CardContainer>
+      <h1>Hola Mundo!!</h1>
+    </CardContainer>
+  );
+  ```
+
+- **Ejemplo con colores personalizados y onClick**:
+
+  ```tsx
+  import { CardContainer } from "./components/CardContainer/CardContainer";
+  import { css } from "styled-components";
+  import { SUCCESS_COLOR } from "./assets/colors/global-colors";
+
+  const ExampleWithColors = () => (
+    <CardContainer
+      onClick={() => alert("Salas Libres")}
       customStyle={css`
-        background-color: #4285f4;
-        &:hover {
-          background-color: #6ea6ffff;
+        width: 400px;
+        height: 80px;
+        h1 {
+          color: ${SUCCESS_COLOR};
+          margin: 0;
         }
-        svg {
-          color: white;
+        h4 {
+          color: ${"#8a96a8"};
+          margin: 0;
         }
       `}
-      onClick={() => console.log("Settings clicked!")}
     >
-      <LucideIcon />
-    </IconButton>
+      <h1>4</h1>
+      <h4>Salas Libres</h4>
+    </CardContainer>
   );
   ```
 

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -78,7 +78,7 @@ const VARIANT_STYLES = {
 };
 
 export const ButtonStyled = styled.button<ButtonProps>`
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   gap: ${({ $hasIcon }) => ($hasIcon ? "0.5rem" : "0")};

--- a/src/components/CardContainer/CardContainer.tsx
+++ b/src/components/CardContainer/CardContainer.tsx
@@ -1,0 +1,6 @@
+import { CardContainerStyled } from "./styles";
+import type { CardContainerProps } from "./types";
+
+export function CardContainer({ children, customStyle, onClick }: CardContainerProps) {
+    return <CardContainerStyled $customStyle={customStyle} onClick={onClick && onClick}>{children}</CardContainerStyled>
+}

--- a/src/components/CardContainer/styles.ts
+++ b/src/components/CardContainer/styles.ts
@@ -1,0 +1,22 @@
+import styled, { type CSSProp } from "styled-components";
+import { DARK_COLOR, WHITE_COLOR } from "../../assets/colors/global-colors";
+
+const CC_BORDER_COLOR = "#e5e7eb";
+
+type CardContainerStyledProps = {
+  $customStyle?: CSSProp;
+};
+
+export const CardContainerStyled = styled.div<CardContainerStyledProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background-color: ${WHITE_COLOR};
+  border-radius: 0.75rem;
+  border-width: 0.063rem;
+  border-color: ${CC_BORDER_COLOR};
+  box-shadow: 0 0.063rem 0.125rem ${DARK_COLOR}d;
+  ${({ $customStyle }) => $customStyle && $customStyle}
+`;

--- a/src/components/CardContainer/types.ts
+++ b/src/components/CardContainer/types.ts
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+import type { CSSProp } from "styled-components";
+
+export type CardContainerProps = {
+  children: ReactNode;
+  onClick?: () => void;
+  customStyle?: CSSProp;
+};


### PR DESCRIPTION
Tareas realizadas:
- Se agrega componente **CardContainer**: Componente contenedor reutilizable que permite mostrar contenido dentro de un diseño estilizado. Ideal para mostrar tarjetas informativas o secciones destacadas en la interfaz de usuario. Está sujeto a cambios, en caso que lo requiera, durante el proceso de desarrollo.
- Se actualiza README.

<img width="722" height="214" alt="image" src="https://github.com/user-attachments/assets/347602b8-0489-44b9-ac1b-51db6337de87" />
